### PR TITLE
feat: add generic support for search

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -1,5 +1,5 @@
 import type { Endpoint, IOramaClient, Method, OramaInitResponse, HeartBeatConfig, OramaError, Override } from './types.js'
-import type { SearchParams, Results, AnyDocument, AnyOrama, Nullable } from '@orama/orama'
+import type { SearchParams, Results, AnyDocument, AnyOrama, Nullable, InternalTypedDocument } from '@orama/orama'
 import type { Message, InferenceType, Interaction } from './answerSession.js'
 import { formatElapsedTime } from '@orama/orama/components'
 import { createId } from '@paralleldrive/cuid2'
@@ -103,7 +103,7 @@ export class OramaClient {
     this.init()
   }
 
-  public async search(query: ClientSearchParams, config?: SearchConfig): Promise<Nullable<Results<AnyDocument>>> {
+  public async search<SchemaType extends object, DocumentType extends InternalTypedDocument<SchemaType> = AnyDocument>(query: ClientSearchParams, config?: SearchConfig): Promise<Nullable<Results<DocumentType>>> {
     await this.initPromise
 
     const currentRequestNumber = ++this.searchRequestCounter

--- a/src/client.ts
+++ b/src/client.ts
@@ -103,7 +103,8 @@ export class OramaClient {
     this.init()
   }
 
-  public async search<SchemaType extends object, DocumentType extends InternalTypedDocument<SchemaType> = AnyDocument>(query: ClientSearchParams, config?: SearchConfig): Promise<Nullable<Results<DocumentType>>> {
+  public async search(query: ClientSearchParams, config?: SearchConfig): Promise<Nullable<Results<AnyDocument>>>;
+  public async search<SchemaType extends object, DocumentType extends InternalTypedDocument<SchemaType> = InternalTypedDocument<SchemaType>>(query: ClientSearchParams, config?: SearchConfig): Promise<Nullable<Results<DocumentType>>> {
     await this.initPromise
 
     const currentRequestNumber = ++this.searchRequestCounter


### PR DESCRIPTION
This PR adds support for generics to be passed to the Orama Cloud's `search` APIs