### PR TITLE
fix: #40 error with web import

### DIFF
--- a/tsup.lib.js
+++ b/tsup.lib.js
@@ -10,9 +10,10 @@ export default defineConfig({
   minify: true,
   format: ['cjs', 'esm', 'iife'],
   globalName: 'OramaClient',
+  platform: 'neutral',
   dts: true,
   clean: true,
   bundle: true,
   outDir,
-  noExternal: ['@orama']
+  noExternal: ['@orama', '@paralleldrive']
 })


### PR DESCRIPTION
This addresses the issue with web imports. `@paralleldrive` was not  included in the bundle so importing `dist/` files directly fails.

Additionally, platform was changed to `neutral` as it was causing issues with browser module import. 

Note, when importing esm directly into html `<script type="module">` one should use `dist/index.js`